### PR TITLE
Feature/76 set query parameters when seaching books

### DIFF
--- a/src/lib/GoogleBooksAPI/RequestManage.test.ts
+++ b/src/lib/GoogleBooksAPI/RequestManage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { requestBookInfo, getThumbnailByIsbn, getBookInfosByQueries, requestBookInfoWithPartialResource } from "./RequestManage";
+import { requestBookInfo, getThumbnailByIsbn, requestBookInfosByQueries, requestBookInfoWithPartialResource } from "./RequestManage";
 import { getTestData } from "$lib/vitest-setup";
 import type { BookInfo } from "$lib/server/models/BookInfo";
 
@@ -82,35 +82,35 @@ describe('requestBookInfoWithPartialResource', () => {
   });
 });
 
-describe('getBookInfosByQueries', () => {
+describe('requestBookInfosByQueries', () => {
   let testData: BookInfo;
   beforeEach(() => {
     testData = getTestData();
   })
 
   it('タイトルを条件にして一致した書誌データを取得できるか',async () => {
-    const result = await getBookInfosByQueries(testData.title, '', '');
+    const result = await requestBookInfosByQueries(testData.title, '', '');
 
     //タイトル指定は複数取れるので、一致させずに1件でもあればOK
     expect(result.items).toBeDefined();
   });
 
   it('著者名を条件にして一致した書誌データを取得できるか', async () => {
-    const result = await getBookInfosByQueries('', testData.author[0], '');
+    const result = await requestBookInfosByQueries('', testData.author[0], '');
 
     //著者指定は複数取れるので、一致させずに1件でもあればOK
     expect(result.items).toBeDefined();
   });
 
   it('ISBNを条件にして一致した書誌データを取得できるか', async () => {
-    const result = await getBookInfosByQueries('', '', testData.identifier?.isbn_13!);
+    const result = await requestBookInfosByQueries('', '', testData.identifier?.isbn_13!);
 
     expect(result.items).toBeDefined();
     expect(result.items![0].volumeInfo?.title).toEqual(testData.title);
   });
   
   it('複数条件で書誌データを取得できるか', async () => {
-    const result = await getBookInfosByQueries(testData.title, testData.author[0], testData.identifier?.isbn_13!);
+    const result = await requestBookInfosByQueries(testData.title, testData.author[0], testData.identifier?.isbn_13!);
 
     expect(result.items).toBeDefined();
     expect(result.items![0].volumeInfo?.title).toEqual(testData.title);
@@ -118,14 +118,14 @@ describe('getBookInfosByQueries', () => {
 
   //rejectを確認
   it('queriesが無い場合にRejectされること', () => {
-    getBookInfosByQueries('', '', '')
+    requestBookInfosByQueries('', '', '')
     .catch((e: Error) => {
       expect(e.message).toEqual('検索条件が入力されていません。');
     });
   });
 
   it('リクエスト結果が0件の際にRejectされること', () => {
-    getBookInfosByQueries('', '', '0000')
+    requestBookInfosByQueries('', '', '0000')
     .catch((e: Error) => {
       expect(e.message).toEqual('検索条件に合う書誌情報が見つかりませんでした。');
     });

--- a/src/lib/GoogleBooksAPI/RequestManage.ts
+++ b/src/lib/GoogleBooksAPI/RequestManage.ts
@@ -24,7 +24,7 @@ export async function requestBookInfoWithPartialResource(queries: string[], reso
 }
 
 /**書名、著者名とISBNのいずれか、または全てを指定して書誌データを取得する */
-export async function getBookInfosByQueries(booktitle: string, author: string, isbn_13: string, maxResults = 10, startIndex = 0): Promise<books_v1.Schema$Volumes>{
+export async function requestBookInfosByQueries(booktitle: string, author: string, isbn_13: string, maxResults = 10, startIndex = 0): Promise<books_v1.Schema$Volumes>{
   const queries: string[] = [];
   if (booktitle) { queries.push(`intitle:${booktitle}`); }
   if (author) { queries.push(`inauthor:${author}`); }

--- a/src/lib/GoogleBooksAPI/RequestManage.ts
+++ b/src/lib/GoogleBooksAPI/RequestManage.ts
@@ -24,7 +24,7 @@ export async function requestBookInfoWithPartialResource(queries: string[], reso
 }
 
 /**書名、著者名とISBNのいずれか、または全てを指定して書誌データを取得する */
-export async function requestBookInfosByQueries(booktitle: string, author: string, isbn_13: string, maxResults = 10, startIndex = 0): Promise<books_v1.Schema$Volumes>{
+export async function requestBookInfosByQueries(booktitle: string, author: string, isbn_13: string, maxResults: number, startIndex: number): Promise<books_v1.Schema$Volumes>{
   const queries: string[] = [];
   if (booktitle) { queries.push(`intitle:${booktitle}`); }
   if (author) { queries.push(`inauthor:${author}`); }

--- a/src/lib/components/search/ContentModal.test.ts
+++ b/src/lib/components/search/ContentModal.test.ts
@@ -1,12 +1,12 @@
 import { render, fireEvent, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi, vitest } from 'vitest';
-import { getBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
+import { requestBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
 import type { books_v1 } from 'googleapis';
 import ContentModal from '$lib/components/search/ContentModal.svelte';
 
 describe('SeachingModal', async () => {
 	const isbn = '978-4-15-120051-9';
-	const result: books_v1.Schema$Volumes = await getBookInfosByQueries('', '', isbn);
+	const result: books_v1.Schema$Volumes = await requestBookInfosByQueries('', '', isbn);
 	const item: books_v1.Schema$Volume = result.items![0];
 
   afterEach(() => {

--- a/src/lib/components/search/SearchModal.svelte
+++ b/src/lib/components/search/SearchModal.svelte
@@ -79,7 +79,7 @@
 						/>
 					</li>
 				</ul>
-				<input type="hidden" value="1" name="page" aria-label="name">
+				<input type="hidden" value="0" name="page" aria-label="name">
 			</div>
 			<span class="bg-stone-400 h-[1px]" />
 			<div class="h-14 flex flex-row justify-end items-center">

--- a/src/lib/components/search/SearchModal.svelte
+++ b/src/lib/components/search/SearchModal.svelte
@@ -79,6 +79,7 @@
 						/>
 					</li>
 				</ul>
+				<input type="hidden" value="1" name="page" aria-label="name">
 			</div>
 			<span class="bg-stone-400 h-[1px]" />
 			<div class="h-14 flex flex-row justify-end items-center">

--- a/src/lib/components/search/parts/DetailContent.test.ts
+++ b/src/lib/components/search/parts/DetailContent.test.ts
@@ -1,12 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
-import { getBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
+import { requestBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
 import DetailContent from '$lib/components/search/parts/DetailContent.svelte';
 import type { books_v1 } from 'googleapis';
 
 describe('DetailContent', async () => {
 	const isbn = '978-4-15-120051-9';
-	const result: books_v1.Schema$Volumes = await getBookInfosByQueries('', '', isbn);
+	const result: books_v1.Schema$Volumes = await requestBookInfosByQueries('', '', isbn);
 	const item: books_v1.Schema$Volume = result.items![0];
 
 	it('レンダリング', async () => {

--- a/src/lib/components/search/parts/DetailContent.test.ts
+++ b/src/lib/components/search/parts/DetailContent.test.ts
@@ -6,7 +6,7 @@ import type { books_v1 } from 'googleapis';
 
 describe('DetailContent', async () => {
 	const isbn = '978-4-15-120051-9';
-	const result: books_v1.Schema$Volumes = await requestBookInfosByQueries('', '', isbn);
+	const result: books_v1.Schema$Volumes = await requestBookInfosByQueries('', '', isbn, 10, 0);
 	const item: books_v1.Schema$Volume = result.items![0];
 
 	it('レンダリング', async () => {

--- a/src/lib/components/search/parts/PagingLabel.svelte
+++ b/src/lib/components/search/parts/PagingLabel.svelte
@@ -1,32 +1,58 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
-	import { createEventDispatcher } from 'svelte';
 
 	export let isLoading = false;
+	export let bookTitle: string | null;
+	export let author: string | null;
+	export let isbn: string | null;
+	export let page: number;
 	export let startIndex: number;
 	export let resultCount: number;
 	export let isBottom = false;
 	const colorLime800 = '#3F6212';
 
-	const dispatch = createEventDispatcher();
-	const clickBackward = () => {
-		dispatch('backward');
+	/**前のページへ再リクエスト*/
+	const pagingBackward = (e: SubmitEvent) => {
+		if (page! <= 0) {
+			e.preventDefault();
+			return;
+		}
+		page! -= 1;
 	};
-	const clickForward = () => {
-		dispatch('forward');
+
+	/**次のページへ再リクエスト*/
+	const pagingForward = (e: SubmitEvent) => {
+		if (startIndex + 10 >= resultCount) {
+			e.preventDefault();
+			return;
+		}
+		page! += 1;
 	};
+
 </script>
 
 {#if !isBottom || !isLoading}
 	<div class="flex max-w-xl">
-		<button	class="hover:bg-stone-300 rounded" type="button" title="前へ" disabled={isLoading} on:click={clickBackward}	>
-			<Icon icon="ph:caret-left" width="32" height="32" color={colorLime800} />
-		</button>
+		<form action="/books/search" class="flex justify-center" on:submit={e => pagingBackward(e)}>
+			<button	class="hover:bg-stone-300 rounded" type="submit" title="前へ" disabled={isLoading}>
+				<Icon icon="ph:caret-left" width="32" height="32" color={colorLime800} />
+			</button>	
+			<input type="hidden" value={bookTitle} name="booktitle">
+			<input type="hidden" value={author} name="author">
+			<input type="hidden" value={isbn} name="isbn">
+			<input type="hidden" bind:value={page} name="page">
+		</form>
 		<span class="m-auto px-2">
       {`${resultCount ? startIndex + 1 : 0}～${startIndex + 10 >= resultCount ? resultCount : startIndex + 10}/${resultCount}`}件
     </span>
-		<button	class="hover:bg-stone-300 rounded" type="button" title="次へ" disabled={isLoading} on:click={clickForward}>
-			<Icon icon="ph:caret-right" width="32" height="32" color={colorLime800} />
-		</button>
+		<form action="/books/search" class="flex justify-center" on:submit={e => pagingForward(e)}>
+			<button	class="hover:bg-stone-300 rounded" type="submit" title="次へ" disabled={isLoading}>
+				<Icon icon="ph:caret-right" width="32" height="32" color={colorLime800} />
+			</button>
+			<input type="hidden" value={bookTitle} name="booktitle">
+			<input type="hidden" value={author} name="author">
+			<input type="hidden" value={isbn} name="isbn">
+			<input type="hidden" bind:value={page} name="page">
+		</form>
 	</div>
 {/if}

--- a/src/lib/components/search/parts/PagingLabel.test.ts
+++ b/src/lib/components/search/parts/PagingLabel.test.ts
@@ -1,43 +1,25 @@
-import { render, fireEvent, screen } from '@testing-library/svelte';
-import { describe, expect, it, vitest } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
 import PagingLabel from '$lib/components/search/parts/PagingLabel.svelte';
 
 describe('PagingLabel', () => {
 	it('レンダリング', () => {
-		render(PagingLabel, {startIndex: 0, resultCount: 30});
+		render(PagingLabel, {bookTitle: '', author: '', isbn: '', page: 0, startIndex: 0, resultCount: 30});
 
 		expect(screen.getByTitle('前へ')).toBeInTheDocument();
 		expect(screen.getByTitle('次へ')).toBeInTheDocument();
 		expect(screen.getByText('1～10/30件')).toBeInTheDocument();
 	});
 
-	it('クリックイベントを検知できること', async () => {
-		const { component } = render(PagingLabel, {startIndex: 0, resultCount: 30});
-
-		const mockPrevious = vitest.fn();
-		const btnPrevious = screen.getByTitle('前へ');
-		component.$on('backward', mockPrevious);
-
-		const mockNext = vitest.fn();
-		const btnNext = screen.getByTitle('次へ');
-		component.$on('forward', mockNext);
-
-		await fireEvent.click(btnPrevious);
-		await fireEvent.click(btnNext);
-
-		expect(mockPrevious).toHaveBeenCalled();
-		expect(mockNext).toHaveBeenCalled();
-	});
-
-	it('isLoadingがTruthyな場合にボタンが操作できないこと', async () => {
-		render(PagingLabel, {startIndex: 0, resultCount: 30, isLoading: true});
+	it('isLoadingがTruethyな場合にボタンが操作できないこと', async () => {
+		render(PagingLabel, {bookTitle: '', author: '', isbn: '', page: 0, startIndex: 0, resultCount: 30, isLoading: true});
 
 		expect(screen.getByTitle('前へ')).toHaveAttribute('disabled');
 		expect(screen.getByTitle('次へ')).toHaveAttribute('disabled');
 	});
 
 	it('isBottomとisLoadingがTruethyな場合に、レンダリングされないこと', () => {
-		const {container} = render(PagingLabel, {startIndex: 0, resultCount: 30, isBottom: true, isLoading: true});
+		const {container} = render(PagingLabel, {bookTitle: '', author: '', isbn: '', page: 0, startIndex: 0, resultCount: 30, isBottom: true, isLoading: true});
 
 		const element = container.querySelector('div.flex');
 		expect(element).toBeNull;

--- a/src/lib/components/search/result/SearchResult.test.ts
+++ b/src/lib/components/search/result/SearchResult.test.ts
@@ -2,7 +2,7 @@ import { render, fireEvent, screen } from '@testing-library/svelte';
 import { describe, expect, it, vitest } from 'vitest';
 import SearchResult from '$lib/components/search/result/SearchResult.svelte';
 import type { books_v1 } from 'googleapis';
-import { getBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
+import { requestBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
 
 //awaitがテストできないので保留
 describe('SearchResult', () => {

--- a/src/routes/(app)/books/search/+page.svelte
+++ b/src/routes/(app)/books/search/+page.svelte
@@ -14,7 +14,6 @@
 	export let data: PageData;
 	let isDisplaySearchModal = false;
 	let resultCount = 0;
-	let startIndex = 0;
 	let isLoading = false;
 
 	let currentBookInfo: books_v1.Schema$Volume;
@@ -31,40 +30,6 @@
 			isLoading = false;
 			resultCount = result.totalItems!;
 			return result;
-		};
-	}
-
-	/**後方にページング*/
-	let pagingBackward = () => {};
-	$: {
-		pagingBackward = () => {
-			if (startIndex === 0) {
-				return;
-			}
-			startIndex -= 10;
-			runPromise = async (): Promise<books_v1.Schema$Volumes> => {
-				isLoading = true;
-				const result = await data.requestBookInfo(startIndex);
-				isLoading = false;
-				return result;
-			};
-		};
-	}
-
-	/**前方にページング*/
-	let pagingForward = () => {};
-	$: {
-		pagingForward = () => {
-			if (startIndex + 10 >= resultCount) {
-				return;
-			}
-			startIndex += 10;
-			runPromise = async (): Promise<books_v1.Schema$Volumes> => {
-				isLoading = true;
-				const result = await data.requestBookInfo(startIndex);
-				isLoading = false;
-				return result;
-			};
 		};
 	}
 
@@ -85,8 +50,8 @@
 			<PrimalyButton type="button" text="再検索"
 				isUseMargin={false}	on:click={() => (isDisplaySearchModal = !isDisplaySearchModal)}
 			/>
-			<PagingLabel {startIndex}	{resultCount}	{isLoading}	
-        on:backward={pagingBackward} on:forward={pagingForward}
+			<PagingLabel bookTitle={data.bookTitle} author={data.author} isbn={data.isbn} 
+				page={data.page} startIndex={data.startIndex} {resultCount} {isLoading}
 			/>
 		</div>
 		<SearchModal bind:isDisplay={isDisplaySearchModal} action="" />
@@ -95,8 +60,8 @@
 	<div class="flex flex-col p-1 contentHeight overflow-auto customScroll">
 		<SearchResult {runPromise} on:click={(event) => displayDetail(event.detail)} />
 		<div class="flex justify-center py-2">
-			<PagingLabel {startIndex}	{resultCount}	{isLoading}	
-        isBottom={true} on:backward={pagingBackward} on:forward={pagingForward}
+			<PagingLabel bookTitle={data.bookTitle} author={data.author} isbn={data.isbn}
+			page={data.page} startIndex={data.startIndex} {resultCount} {isLoading} isBottom={true} 
 			/>
 		</div>
 		{#if isDisplayDetail}

--- a/src/routes/(app)/books/search/+page.svelte
+++ b/src/routes/(app)/books/search/+page.svelte
@@ -22,23 +22,14 @@
 	const pageName = '書籍検索';
 	const target = 'searchToast';
 
-	let runPromise = async (): Promise<books_v1.Schema$Volumes> => {
-		isLoading = true;
-		const result = await data.requestBookInfo();
-		isLoading = false;
-		resultCount = result.totalItems!;
-		return result;
-	};
+	let runPromise: () => Promise<books_v1.Schema$Volumes>;
 	$: {
 		//再検索時に再実行されるようreactive化
 		runPromise = async (): Promise<books_v1.Schema$Volumes> => {
 			isLoading = true;
-			//ページングを初期化
-			startIndex = 0;
-			resultCount = 0;
 			const result = await data.requestBookInfo();
-			resultCount = result.totalItems!;
 			isLoading = false;
+			resultCount = result.totalItems!;
 			return result;
 		};
 	}

--- a/src/routes/(app)/books/search/+page.svelte
+++ b/src/routes/(app)/books/search/+page.svelte
@@ -24,7 +24,7 @@
 
 	let runPromise = async (): Promise<books_v1.Schema$Volumes> => {
 		isLoading = true;
-		const result = await data.getBookInfo();
+		const result = await data.requestBookInfo();
 		isLoading = false;
 		resultCount = result.totalItems!;
 		return result;
@@ -36,7 +36,7 @@
 			//ページングを初期化
 			startIndex = 0;
 			resultCount = 0;
-			const result = await data.getBookInfo();
+			const result = await data.requestBookInfo();
 			resultCount = result.totalItems!;
 			isLoading = false;
 			return result;
@@ -53,7 +53,7 @@
 			startIndex -= 10;
 			runPromise = async (): Promise<books_v1.Schema$Volumes> => {
 				isLoading = true;
-				const result = await data.getBookInfo(startIndex);
+				const result = await data.requestBookInfo(startIndex);
 				isLoading = false;
 				return result;
 			};
@@ -70,7 +70,7 @@
 			startIndex += 10;
 			runPromise = async (): Promise<books_v1.Schema$Volumes> => {
 				isLoading = true;
-				const result = await data.getBookInfo(startIndex);
+				const result = await data.requestBookInfo(startIndex);
 				isLoading = false;
 				return result;
 			};

--- a/src/routes/(app)/books/search/+page.ts
+++ b/src/routes/(app)/books/search/+page.ts
@@ -6,8 +6,8 @@ export const load = (async (params) => {
   const bookTitle = params.url.searchParams.get('booktitle');
   const author = params.url.searchParams.get('author');
   const isbn = params.url.searchParams.get('isbn');
-  const page = params.url.searchParams.get('page');
-  const count = params.url.searchParams.get('count');
+  const page = Number(params.url.searchParams.get('page'));
+  const startIndex = page > 0 ? page : 1;
 
   //パラメータを条件に検索を行う関数を作成し、クライアント側に渡して実行
   const requestBookInfo = async (startIndex = 0) => requestBookInfosByQueries(bookTitle!, author!, isbn!, 10, startIndex) as books_v1.Schema$Volumes;

--- a/src/routes/(app)/books/search/+page.ts
+++ b/src/routes/(app)/books/search/+page.ts
@@ -1,5 +1,5 @@
 import type { PageLoad } from './$types';
-import { getBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
+import { requestBookInfosByQueries } from '$lib/GoogleBooksAPI/RequestManage';
 import type { books_v1 } from 'googleapis';
 
 export const load = (async (params) => {
@@ -8,6 +8,6 @@ export const load = (async (params) => {
   const isbn = params.url.searchParams.get('isbn');
 
   //パラメータを条件に検索を行う関数を作成し、クライアント側に渡して実行
-  const getBookInfo = async (startIndex = 0) => getBookInfosByQueries(bookTitle!, author!, isbn!, 10, startIndex) as books_v1.Schema$Volumes;
-  return { getBookInfo, bookTitle, author, isbn };
+  const requestBookInfo = async (startIndex = 0) => requestBookInfosByQueries(bookTitle!, author!, isbn!, 10, startIndex) as books_v1.Schema$Volumes;
+  return { requestBookInfo, bookTitle, author, isbn };
 }) satisfies PageLoad;

--- a/src/routes/(app)/books/search/+page.ts
+++ b/src/routes/(app)/books/search/+page.ts
@@ -6,10 +6,13 @@ export const load = (async (params) => {
   const bookTitle = params.url.searchParams.get('booktitle');
   const author = params.url.searchParams.get('author');
   const isbn = params.url.searchParams.get('isbn');
-  const page = Number(params.url.searchParams.get('page'));
-  const startIndex = page >= 0 ? page : 0;
+  let page = Number(params.url.searchParams.get('page'));
+  page = page >= 0 ? page : 0;
+
+  const maxResults = 10;
+  const startIndex = page > 0 ? page * maxResults : 0;
 
   //パラメータを条件に検索を行う関数を作成し、クライアント側に渡して実行
-  const requestBookInfo = async (startIndex = 0) => requestBookInfosByQueries(bookTitle!, author!, isbn!, 10, startIndex) as books_v1.Schema$Volumes;
-  return { requestBookInfo, bookTitle, author, isbn };
+  const requestBookInfo = async () => requestBookInfosByQueries(bookTitle!, author!, isbn!, maxResults, startIndex) as books_v1.Schema$Volumes;
+  return { requestBookInfo, bookTitle, author, isbn, page, startIndex };
 }) satisfies PageLoad;

--- a/src/routes/(app)/books/search/+page.ts
+++ b/src/routes/(app)/books/search/+page.ts
@@ -6,6 +6,8 @@ export const load = (async (params) => {
   const bookTitle = params.url.searchParams.get('booktitle');
   const author = params.url.searchParams.get('author');
   const isbn = params.url.searchParams.get('isbn');
+  const page = params.url.searchParams.get('page');
+  const count = params.url.searchParams.get('count');
 
   //パラメータを条件に検索を行う関数を作成し、クライアント側に渡して実行
   const requestBookInfo = async (startIndex = 0) => requestBookInfosByQueries(bookTitle!, author!, isbn!, 10, startIndex) as books_v1.Schema$Volumes;

--- a/src/routes/(app)/books/search/+page.ts
+++ b/src/routes/(app)/books/search/+page.ts
@@ -7,7 +7,7 @@ export const load = (async (params) => {
   const author = params.url.searchParams.get('author');
   const isbn = params.url.searchParams.get('isbn');
   const page = Number(params.url.searchParams.get('page'));
-  const startIndex = page > 0 ? page : 1;
+  const startIndex = page >= 0 ? page : 0;
 
   //パラメータを条件に検索を行う関数を作成し、クライアント側に渡して実行
   const requestBookInfo = async (startIndex = 0) => requestBookInfosByQueries(bookTitle!, author!, isbn!, 10, startIndex) as books_v1.Schema$Volumes;


### PR DESCRIPTION
検索処理をリファクタリングし、URLとページ内容が一致するように修正。
今まで、ページング時はJSを使って内部で再リクエストしていたが、
クエリパラメータでページを指定して、読み込み時にページングし、
ページの前後移動時は再度formタグをpostして、パラメータを書き換えるように変更。