### PR TITLE
Feature/74 prevent to save same items by multiple times

### DIFF
--- a/src/lib/components/search/ContentModal.svelte
+++ b/src/lib/components/search/ContentModal.svelte
@@ -51,7 +51,10 @@
 
 		closeModalAndLoader();
 		//ユーザ用のメッセージを設定してイベントを発行
-		handleRequest(response.ok, response.ok ? '登録しました' : '登録に失敗しました。\<br\>時間をおいて再度登録してください。');
+		const reseponseMessage = 
+			response.ok ? '登録しました' : 
+			response.status === 409 ? '登録済みの書籍です' : '登録に失敗しました。\<br\>時間をおいて再度登録してください。';
+		handleRequest(response.ok, reseponseMessage);
 	}
 
 </script>

--- a/src/lib/server/database/bookInfo.service.test.ts
+++ b/src/lib/server/database/bookInfo.service.test.ts
@@ -233,6 +233,16 @@ describe('insertBookInfo', () => {
     expect(result.ok).toBeFalsy();
   });
 
+  it('保存済み書誌情報と同じデータを保存しようとした際にエラーステータスが返ってくること', async () => {
+    const preData = await col.insertOne(testData);
+    expect(await preData.acknowledged).toBeTruthy();
+  
+    const result = await service.insertBookInfo({ bookInfos: col }, testData);
+    
+    expect(result.ok).toBeFalsy();
+    expect(result.status).toEqual(409);
+  });
+
   //MongoDB側のコレクション定義をして弾く必要があるのでスキップ
   it.skip('データが不正(undefinedを渡す)な場合にエラーステータスが返ってくること', async () => {  
     const result = await service.insertBookInfo({ bookInfos: col }, testData);

--- a/src/lib/server/database/bookInfo.service.test.ts
+++ b/src/lib/server/database/bookInfo.service.test.ts
@@ -242,16 +242,36 @@ describe('insertBookInfo', () => {
 });
 
 describe('isDuplicateBookInfo', () => {
-  it.skip('保存済み書誌データと同じデータを指定した際にTrueが返ること', () => {
+  let testData: BookInfo;
+  let userId: string;
+  let gapiId = 'gapiId';
+  beforeEach(async () => {
+    testData = getTestData();
+    userId = testData.userId;
 
+    testData.gapiId = gapiId;
+    const preData = await col.insertOne(testData);
+    expect(await preData.acknowledged).toBeTruthy();
   })
 
-  it.skip('保存済みでない書誌データを指定した際にFalseが返ること', () => {
-
+  it('保存済みデータに一致するユーザIDとgapiIDを指定した際にTrueが返ること', async () => {
+    const isDuplicate = await service.isDuplicateBookInfo({ bookInfos: col }, userId, gapiId);
+    expect(isDuplicate).toBeTruthy();
   })
 
-  it.skip('', () => {
+  it('保存済みデータに一致しないユーザIDとgapiIDを指定した際にFalseが返ること', async () => {
+    const isDuplicate = await service.isDuplicateBookInfo({ bookInfos: col }, `test_${userId}`, `test_${gapiId}`);
+    expect(isDuplicate).toBeFalsy();
+  })
 
+  it('保存済みデータに一致するユーザIDと、一致しないgapiIDを指定した際にFalseが返ること', async () => {
+    const isDuplicate = await service.isDuplicateBookInfo({ bookInfos: col }, userId, `test_${gapiId}`);
+    expect(isDuplicate).toBeFalsy();
+  })
+
+  it('保存済みデータに一致しないユーザIDと、一致するgapiIDを指定した際にFalseが返ること', async () => {
+    const isDuplicate = await service.isDuplicateBookInfo({ bookInfos: col }, `test_${userId}`, gapiId);
+    expect(isDuplicate).toBeFalsy();
   })
 });
 

--- a/src/lib/server/database/bookInfo.service.test.ts
+++ b/src/lib/server/database/bookInfo.service.test.ts
@@ -241,6 +241,20 @@ describe('insertBookInfo', () => {
   });
 });
 
+describe('isDuplicateBookInfo', () => {
+  it.skip('保存済み書誌データと同じデータを指定した際にTrueが返ること', () => {
+
+  })
+
+  it.skip('保存済みでない書誌データを指定した際にFalseが返ること', () => {
+
+  })
+
+  it.skip('', () => {
+
+  })
+});
+
 describe('updateBookInfo', () => {
   let testData: BookInfo;
   beforeEach(() => {

--- a/src/lib/server/database/bookInfo.service.ts
+++ b/src/lib/server/database/bookInfo.service.ts
@@ -19,7 +19,7 @@ export async function getBookInfo(collections: collections, userId: string): Pro
   return bookInfos;
 }
 
-/**直近で読んだ、ユーザIDに紐づいた書誌データを取得する */
+/**直近で読んだ、ユーザIDに紐づいた書誌データを1件取得する */
 export async function getRecentBookInfo(collections: collections, userId: string): Promise<BookInfo[]>{
   let bookInfos: BookInfo[] = [];
   if (typeof userId !== 'string') { return bookInfos; }
@@ -96,6 +96,15 @@ export async function insertBookInfo(collections: collections, bookInfo: BookInf
   }
 
   return response;
+}
+
+/**同様の書誌データが既に保存されているか */
+async function isDuplicateBookInfo(collections: collections, bookInfo: BookInfo): Promise<boolean> {
+  let isDuplicate = true;
+
+
+  
+  return isDuplicate;
 }
 
 /**書誌データを更新する */

--- a/src/lib/server/database/bookInfo.service.ts
+++ b/src/lib/server/database/bookInfo.service.ts
@@ -84,7 +84,7 @@ export async function getBookInfoByStatus(collections: collections, userId: stri
 export async function insertBookInfo(collections: collections, bookInfo: BookInfo): Promise<Response>{
   let response = new Response('書誌データの作成に失敗しました。', {status: 400});
   if (await isDuplicateBookInfo(collections, bookInfo.userId, bookInfo.gapiId!)){
-    return new Response('登録済みの書誌データです。', {status: 400});
+    return new Response('登録済みの書誌データです。', {status: 409}); //409conflict
   }
 
   try {

--- a/src/lib/server/database/bookInfo.service.ts
+++ b/src/lib/server/database/bookInfo.service.ts
@@ -99,10 +99,17 @@ export async function insertBookInfo(collections: collections, bookInfo: BookInf
 }
 
 /**同様の書誌データが既に保存されているか */
-async function isDuplicateBookInfo(collections: collections, bookInfo: BookInfo): Promise<boolean> {
-  let isDuplicate = true;
+export async function isDuplicateBookInfo(collections: collections, userId: string, gapiId: string): Promise<boolean> {
+  let isDuplicate = false;
 
-
+  try {
+    const bookInfos = await collections.bookInfos?.find({userId, gapiId}).toArray() as BookInfo[];
+    isDuplicate = bookInfos.length === 0 ? false : true;
+  }
+  catch (error) {
+    console.log(error);
+    console.log('書誌データの取得に失敗しました。');
+  }
   
   return isDuplicate;
 }

--- a/src/lib/server/database/bookInfo.service.ts
+++ b/src/lib/server/database/bookInfo.service.ts
@@ -83,6 +83,9 @@ export async function getBookInfoByStatus(collections: collections, userId: stri
 /**書誌データを保存する */
 export async function insertBookInfo(collections: collections, bookInfo: BookInfo): Promise<Response>{
   let response = new Response('書誌データの作成に失敗しました。', {status: 400});
+  if (await isDuplicateBookInfo(collections, bookInfo.userId, bookInfo.gapiId!)){
+    return new Response('登録済みの書誌データです。', {status: 400});
+  }
 
   try {
     const result = await collections.bookInfos?.insertOne(bookInfo);

--- a/src/lib/server/models/BookInfo.ts
+++ b/src/lib/server/models/BookInfo.ts
@@ -47,6 +47,7 @@ export class BookInfo {
 		this.memorandum = '';
 		this.isVisible = true;
 		this.identifier = getIdentifier(volume.volumeInfo?.industryIdentifiers);
+		this.gapiId = volume.id ?? this.title; //gapi固有の情報なので入れたら微妙な感じではある
 	}
 }
 

--- a/src/lib/server/models/BookInfo.ts
+++ b/src/lib/server/models/BookInfo.ts
@@ -28,7 +28,8 @@ export class BookInfo {
 		isbn_13?: string;
 		isbn_10?: string;
 	};
-	public shelfCategory?: ObjectId[];
+	public shelfCategory?: ObjectId[]
+	public gapiId?: string;
 
 	/**GAPIのvolumeで初期化する */
 	constructor(volume: books_v1.Schema$Volume, userId: string){


### PR DESCRIPTION
登録済みの書誌データを複数保存できないように修正。
書誌データのキーとしてGoogleBooksAPI内のIDを使っており、
これがGAPI固有の情報なのが正直気になるが、一旦このIDを使って管理する。